### PR TITLE
add market fund amount to run js

### DIFF
--- a/scripts/run.js
+++ b/scripts/run.js
@@ -4,6 +4,7 @@ const deployDeps = require('./deploy_deps')
 
 const FEE = 20
 const TRADING_PERIOD = 60 * 60 * 24 * 7
+const MARKET_FUND_AMOUNT = 10 * 10 ** 18
 
 const defaultOwner = process.env.OWNER
 
@@ -38,6 +39,7 @@ module.exports = async (
       '--app-init-args',
       FEE,
       TRADING_PERIOD,
+      MARKET_FUND_AMOUNT,
       miniMeTokenAddress,
       futarchyOracleFactoryAddress,
       centralizedOracleFactoryAddress,


### PR DESCRIPTION
Adding MARKET_FUND_AMOUNT to the args for `--app-init-args` so that `npm run start:aragon` works.