### PR TITLE
Update upper lower bounds on clients

### DIFF
--- a/app/actions/index.js
+++ b/app/actions/index.js
@@ -54,8 +54,13 @@ export const propValueLoadingError = ({ prop, errorMessage }) => ({
   errorMessage
 })
 
-export const newDecision = (bytes32Script, question) => dispatch => {
-  return client.newDecision(bytes32Script, question).then(txHash => {
+export const newDecision = ({
+  bytes32Script,
+  question,
+  lowerBound,
+  upperBound
+}) => dispatch => {
+  return client.newDecision(bytes32Script, question, lowerBound, upperBound).then(txHash => {
     dispatch(newDecisionTxPending({ question, txHash }))
   }, err => {
     console.error(`newDecision: ${err}`)

--- a/app/client/index.js
+++ b/app/client/index.js
@@ -72,7 +72,7 @@ export const calcProfits = async (decisionId, outcomeTokenAmounts) => {
 // token transfer. Aragon client uses the `token` property in transaction
 // options to send a token approval transaction before the requested
 // transaction (in this case, a `newDecision` transaction)
-export const newDecision = async (script, question) => {
+export const newDecision = async (script, question, lowerBound, upperBound) => {
   const address = await call('token')
   const value = await marketFundAmount()
   const transactionOptions = {
@@ -84,6 +84,8 @@ export const newDecision = async (script, question) => {
     'newDecision',
     script,
     question,
+    lowerBound,
+    upperBound,
     transactionOptions
   )
 }

--- a/app/containers/CreateDecisionMarketFormContainer.js
+++ b/app/containers/CreateDecisionMarketFormContainer.js
@@ -5,6 +5,8 @@ import { newDecision, hidePanel } from '../actions'
 import CreateDecisionMarketForm from '../components/CreateDecisionMarketForm'
 
 const ZERO_BYTES_32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const LOWER_BOUND = 0
+const UPPER_BOUND = 1000
 
 const mapStateToProps = state => ({
   tokenBalance: state.tokenBalance,
@@ -14,7 +16,12 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   createDecision: async values => {
     dispatch(hidePanel())
-    dispatch(newDecision(ZERO_BYTES_32, values.question))
+    dispatch(newDecision({
+      bytes32Script: ZERO_BYTES_32,
+      question: values.question,
+      lowerBound: LOWER_BOUND,
+      upperBound: UPPER_BOUND
+    }))
   }
 })
 

--- a/scripts/seed_data/decisions.js
+++ b/scripts/seed_data/decisions.js
@@ -16,6 +16,9 @@ module.exports = async callback => {
     const token = ERC20.at(await app.token())
     const marketFundAmount = await app.marketFundAmount()
 
+    const lowerBound = 0
+    const upperBound = 1000
+
     const decisions = [
       { executionScript: '', metadata: 'Execute a transfer of 1,000 ETH to 0xa1b2c3...?' },
       { executionScript: '', metadata: 'Increase the minimum funding parameter to 45 TKN?' },
@@ -26,8 +29,8 @@ module.exports = async callback => {
       let decision = decisions[i]
       console.log(`token.approve(${app.address}, ${marketFundAmount})`)
       await token.approve(app.address, marketFundAmount)
-      console.log(`app.newDecision(${decision.executionScript}, ${decision.metadata})`)
-      await app.newDecision(decision.executionScript, decision.metadata)
+      console.log(`app.newDecision(${decision.executionScript}, ${decision.metadata}, ${lowerBound}, ${upperBound})`)
+      await app.newDecision(decision.executionScript, decision.metadata, lowerBound, upperBound)
       console.log('')
     }
 


### PR DESCRIPTION
add some hardcoded upper and lower bounds to the seeding script and the front-end, to get things working after the smart contract `newDecision` function update to add `lowerBound` and `upperBound` parameters