### PR TITLE
Prevent buying short and long tokens for the same outcome

### DIFF
--- a/contracts/Futarchy.sol
+++ b/contracts/Futarchy.sol
@@ -229,6 +229,10 @@ contract Futarchy is AragonApp, IForwarder {
       public
       returns (uint[2] yesCosts, uint[2] noCosts)
     {
+      // prevent buying short and long for the same outcome
+      require(yesPurchaseAmounts[0] == 0 || yesPurchaseAmounts[1] == 0);
+      require(noPurchaseAmounts[0] == 0 || noPurchaseAmounts[1] == 0);
+
       // set necessary contracts
       CategoricalEvent categoricalEvent = decisions[decisionId].futarchyOracle.categoricalEvent();
       StandardMarket yesMarket = decisions[decisionId].futarchyOracle.markets(0);

--- a/test/Futarchy.test.js
+++ b/test/Futarchy.test.js
@@ -53,8 +53,9 @@ const TWO = 2 * 10 ** 18
 
 contract('Futarchy', (accounts) => {
   let APP_MANAGER_ROLE
-  let futarchyBase
+  let daoFactory, futarchyBase
   let futarchy, token, priceOracleFactory, futarchyOracleFactory, lmsrMarketMaker
+  let futarchyOracleFactoryFull, futarchyOracleFactoryMock
   let executionTarget
 
   const root = accounts[0]
@@ -486,6 +487,17 @@ contract('Futarchy', (accounts) => {
       await token.approve(futarchy.address, TWENTY, {from: account2})
       await futarchy.buyMarketPositions(0, TWENTY, [THREE, 0], [0, THREE], {from: account2})
       expect((await account2DecisionBalances()).yesShort).to.equal(THREE)
+    })
+
+    it('fails trying to buy both short and long for the same outcome', async () => {
+      // yes
+      await assertRevert(async () => {
+        await futarchy.buyMarketPositions(0, TWENTY, [FIVE, FIVE], [0, FIVE], {from: root})
+      })
+      // no
+      await assertRevert(async () => {
+        await futarchy.buyMarketPositions(0, TWENTY, [FIVE, 0], [FIVE, FIVE], {from: root})
+      })
     })
 
     describe('when trader is trading again on the same market', async () => {


### PR DESCRIPTION
I'm still struggling to understand precisely how the numbers work for this conditional market, but unless I misunderstood or missed something, I think that in `buyMarketPositions` buying short and long tokens for the same outcome ("yes" or "no") should be prevented.
Otherwise, it seems to me that in [this loop](https://github.com/levelkdev/futarchy-app/blob/master/contracts/Futarchy.sol#L244) collateral tokens would be used twice in the same market.
I'm aware this is currently not possible from the UI (which reinforces this assumption), bt I think it should be checked at contract level too if it's correct.
The fact that I couldn't find any example in the tests or the seed script doing it (buying both short and long for the same initial outcome) makes me think that the assumption is correct too. 
Finally, I ran a little test, copying [this one](https://github.com/levelkdev/futarchy-app/blob/master/test/Futarchy.test.js#L481) but buying `FIVE` short and `FIVE` long for Yes outcome from root account. the results were:
Original test:
```
Root:
  yesCollateral: 17.279035902300609000,
  noCollateral: 17.279035902300609000,
  yesShort: 5,
  yesLong: 0,
  noShort: 0,
  noLong: 5
Account 2:
  yesCollateral: 18.164313446164093000,
  noCollateral: 18.164313446164093000,
  yesShort: 3,
  yesLong: 0,
  noShort: 0,
  noLong: 3
```
New one:
```
Root:
  yesCollateral: 14.990000000000000000,
  noCollateral: 17.279035902300609000,
  yesShort: 5,
  yesLong: 5,
  noShort: 0,
  noLong: 5
Account 2:  
  yesCollateral: 18.419005355346252000,
  noCollateral: 18.164313446164093000,
  yesShort: 3,
  yesLong: 0,
  noShort: 0,
  noLong: 3
```
So it seems it would be beneficial to always bet on both.
