### PR TITLE
update decision data when buy/redeem events are fired

### DIFF
--- a/app/middleware/appEventInterceptor.js
+++ b/app/middleware/appEventInterceptor.js
@@ -14,6 +14,14 @@ const appEventInterceptor = store => next => action => {
         decisionId: action.returnValues.decisionId,
         action
       })
+
+      // if this event was fired after the initial app load
+      if(state.latestBlock && action.blockNumber > state.latestBlock.number) {
+        store.dispatch(
+          fetchDecisionData(action.returnValues.decisionId)
+        )
+      }
+
       break
     case 'START_DECISION_EVENT':
       action = {


### PR DESCRIPTION
checks to see if this is a buy/redeem event that happened after the initial app load, and update decision data in app state. this ensures that the correct data will be there when the next buyMarketPositions transaction is constructed by the UI, minimizing the chance of an unexpected revert.

fixes https://github.com/levelkdev/futarchy-app/issues/121