### PR TITLE
Do not set price oracle through Futarchy.sol + adjust CentralizedTimedOracle

### DIFF
--- a/contracts/DecisionLib.sol
+++ b/contracts/DecisionLib.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.24;
 
-import './Oracles/CentralizedTimedOracle.sol'; /* TODO: switch to IScalarPriceOracle once we switch from centralized solution */
 import '@gnosis.pm/pm-contracts/contracts/Oracles/FutarchyOracle.sol';
 import '@gnosis.pm/pm-contracts/contracts/Markets/Market.sol';
 import '@gnosis.pm/pm-contracts/contracts/Tokens/ERC20Gnosis.sol';
@@ -35,8 +34,6 @@ library DecisionLib {
     self.futarchyOracle.markets(winningMarketIndex).eventContract().redeemWinnings();
     self.futarchyOracle.categoricalEvent().redeemWinnings();
   }
-
-
 
   /**
   * @dev Checks to see if decision is ready for any transitions, then executes
@@ -222,13 +219,4 @@ library DecisionLib {
     outcomeTokensSold[0] = self.futarchyOracle.markets(marketIndex).netOutcomeTokensSold(0);
     outcomeTokensSold[1] = self.futarchyOracle.markets(marketIndex).netOutcomeTokensSold(1);
   }
-
-  function setPriceOutcome(
-    Decision storage self,
-    int price
-  ) {
-    CentralizedTimedOracle priceOracle = CentralizedTimedOracle(self.futarchyOracle.markets(0).eventContract().oracle());
-    priceOracle.setOutcome(price);
-  }
-
 }

--- a/contracts/Futarchy.sol
+++ b/contracts/Futarchy.sol
@@ -351,21 +351,6 @@ contract Futarchy is AragonApp, IForwarder {
     balances.noLong = balances.noLong.add(noOutcomeAmounts[1]);
   }
 
-  /**
-  * @notice Sets outcome of the price oracle for a specified decision
-  * @param price Price used to set oracle outcome
-  * @param decisionId ID of price oracle's corresponding decision
-  */
-  function setPriceOutcome(
-    uint decisionId,
-    int price
-  )
-    public
-    auth(CREATE_DECISION_ROLE)
-  {
-    decisions[decisionId].setPriceOutcome(price);
-  }
-
   /* IForwarder API */
 
   /* @notice confirms Futarchy implements IForwarder */

--- a/contracts/Oracles/CentralizedTimedOracleFactory.sol
+++ b/contracts/Oracles/CentralizedTimedOracleFactory.sol
@@ -8,6 +8,12 @@ contract CentralizedTimedOracleFactory is IScalarPriceOracleFactory {
 
     event CentralizedTimedOracleCreation(address indexed creator, IScalarPriceOracle centralizedTimedOracle, uint resolutionDate);
 
+    address public owner;
+
+    constructor(address _owner) public {
+      owner = _owner;
+    }
+
     /**
     * @dev Creates a new centralized & time-constrained oracle contract
     * @param resolutionDate date that price oracle can be resolved
@@ -17,7 +23,7 @@ contract CentralizedTimedOracleFactory is IScalarPriceOracleFactory {
         external
         returns (IScalarPriceOracle centralizedTimedOracle)
     {
-        centralizedTimedOracle = IScalarPriceOracle(new CentralizedTimedOracle(msg.sender, resolutionDate));
+        centralizedTimedOracle = IScalarPriceOracle(new CentralizedTimedOracle(owner, resolutionDate));
         emit CentralizedTimedOracleCreation(msg.sender, centralizedTimedOracle, resolutionDate);
     }
 }

--- a/deploy.rinkeby.json
+++ b/deploy.rinkeby.json
@@ -1,7 +1,6 @@
 {
     "dependencyContracts": {
         "MiniMeToken": "0x6917ca90c0670024a9f48aecefd6c3c82fc5d3e9",
-        "CentralizedTimedOracleFactory": "0x14f53093de40e5924af4abe20cdc860995a4fd47",
         "Fixed192x64Math": "0x68407ea068c8348ac50fcd4e3e85b9cd3a7d0e4e",
         "LMSRMarketMaker": "0x5995f896899256ac9496d17a03125b2ea3df34a4",
         "CategoricalEvent": "0xc1ea53b67bfcc1350b2e6b1c9d97b83666c865dd",
@@ -12,7 +11,8 @@
         "EventFactory": "0x525cc4cc523e376a3952f31998aaf312fb9ee82d",
         "StandardMarketWithPriceLoggerFactory": "0x64cec831d0109c40a734384beaf011b9deeebd53",
         "FutarchyOracleFactory": "0x1fad5ae333ef73ea9810bf90846cadbaabb72a36",
-        "DecisionLib": "0xe1a3dfadc0566bef1bc067779f1088706089a277"
+        "DecisionLib": "0xe1a3dfadc0566bef1bc067779f1088706089a277",
+        "CentralizedTimedOracleFactory": "0xf6ed9481e128bb937beceb27bff85dec87653cb2"
     },
     "tokensAllocated": {
         "0x44360017c1460BC0149946b4fad97665c25586b0": "1e+26",

--- a/scripts/deploy_deps.js
+++ b/scripts/deploy_deps.js
@@ -1,4 +1,5 @@
 const tryDeployToNetwork = require('./utilities/tryDeployToNetwork')
+const getAccounts = require('@aragon/os/scripts/helpers/get-accounts')
 
 const globalArtifacts = this.artifacts // Not injected unless called directly via truffle
 const NULL_ADDRESS = '0x00'
@@ -7,7 +8,8 @@ module.exports = async (
   truffleExecCallback,
   {
     artifacts = globalArtifacts,
-    network
+    network,
+    web3
   } = {}
 ) => {
   const MiniMeToken = artifacts.require('MiniMeToken')
@@ -27,15 +29,18 @@ module.exports = async (
     console.log(`Deploying dependencies for "${network}" network`)
     console.log('')
 
+    const ownerAccount = (await getAccounts(web3))[0]
+
     const miniMeToken = await tryDeploy(
-      MiniMeToken, 
+      MiniMeToken,
       'MiniMeToken',
       [ NULL_ADDRESS, NULL_ADDRESS, 0, 'TokenCoin', 0, 'TKN', true ]
     )
 
     const centralizedTimedOracleFactory = await tryDeploy(
       CentralizedTimedOracleFactory,
-      'CentralizedTimedOracleFactory'
+      'CentralizedTimedOracleFactory',
+      [ownerAccount]
     )
 
     const fixed192x64Math = await tryDeploy(
@@ -44,7 +49,7 @@ module.exports = async (
     )
 
     await LMSRMarketMaker.link('Fixed192x64Math', fixed192x64Math.address)
-  
+
     const lmsrMarketMaker = await tryDeploy(
       LMSRMarketMaker,
       'LMSRMarketMaker'

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -35,7 +35,7 @@ module.exports = async (
 
     const {
       miniMeTokenAddress
-    } = await deployDeps(null, { artifacts, network })
+    } = await deployDeps(null, { artifacts, network, web3 })
     console.log('')
 
     await distributeTokens(null, {

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -42,7 +42,7 @@ module.exports = async (
       futarchyOracleFactoryAddress,
       centralizedTimedOracleFactoryAddress,
       lmsrMarketMakerAddress
-    } = await deployDeps(null, { artifacts, network })
+    } = await deployDeps(null, { artifacts, network, web3 })
     console.log('')
 
     await distributeTokens(null, {

--- a/test/Futarchy.test.js
+++ b/test/Futarchy.test.js
@@ -743,7 +743,6 @@ contract('Futarchy', (accounts) => {
         })
       })
     })
-
   })
 
   describe('redeemWinningCollateralTokens()', () => {


### PR DESCRIPTION
the `setOutcome()` interface for each `IScalarPriceOracle` varies, therefore, `Futarchy.sol` cannot be responsible for setting the Outcome. This also means,  a `Futarchy.sol` cannot be the owner of a `CentralizedTimedOracle()` since it cannot call setOutcome, so had to adjust the `CentralizedTimedOracleFactory`  to choose owner other than `msg.sender`