### PR TITLE
Make internal functions `view` and `public`

### DIFF
--- a/contracts/Oracles/MedianPriceOracle.sol
+++ b/contracts/Oracles/MedianPriceOracle.sol
@@ -43,24 +43,24 @@ contract MedianPriceOracle is ScalarPriceOracleBase, TimedOracle {
     resolutionDatePassed
   {
     bytes32 result;
-    require(_isValidRange(startIndex, endIndex));
+    require(isValidRange(startIndex, endIndex));
     result = medianDataFeed.medianizeByIndices(startIndex, endIndex);
 
     _setOutcome(int(result));
   }
 
-  // Internal Functions
-
-  function _isValidRange(uint startIndex, uint endIndex)
-    internal
+  function isValidRange(uint startIndex, uint endIndex)
+    public
+    view
     returns (bool)
   {
-    return (_isValidStartIndex(startIndex) && _isValidEndIndex(endIndex)) ||
-      _validForNoResultsDuringTimeframe(startIndex, endIndex);
+    return (isValidStartIndex(startIndex) && isValidEndIndex(endIndex)) ||
+      validForNoResultsDuringTimeframe(startIndex, endIndex);
   }
 
-  function _isValidStartIndex(uint startIndex)
-    internal
+  function isValidStartIndex(uint startIndex)
+    public
+    view
     returns (bool)
   {
     (, uint startDate) = medianDataFeed.resultByIndex(startIndex);
@@ -76,8 +76,9 @@ contract MedianPriceOracle is ScalarPriceOracleBase, TimedOracle {
     return startIndexWithinTimeframe && previousIndexBeforeTimeframe;
   }
 
-  function _isValidEndIndex(uint endIndex)
-    internal
+  function isValidEndIndex(uint endIndex)
+    public
+    view
     returns (bool)
   {
     (, uint endDate) = medianDataFeed.resultByIndex(endIndex);
@@ -93,8 +94,9 @@ contract MedianPriceOracle is ScalarPriceOracleBase, TimedOracle {
     return endIndexWithinTimeframe && nextIndexAfterTimeframe;
   }
 
-  function _validForNoResultsDuringTimeframe(uint startIndex, uint endIndex)
-    internal
+  function validForNoResultsDuringTimeframe(uint startIndex, uint endIndex)
+    public
+    view
     returns (bool)
   {
     (, uint startDate) = medianDataFeed.resultByIndex(startIndex);


### PR DESCRIPTION
These don't write to state so they should be marked `view`. Since they're read only, they can all be marked `public` to make them readable by web3 clients. Much easier to deal with validating indexes on the client side if we're using web3/solidity rather than re-writing the require check logic in JS.